### PR TITLE
Remove cache_ts from end of parsed users.json

### DIFF
--- a/slack-backup.sh
+++ b/slack-backup.sh
@@ -340,7 +340,7 @@ printf "done.\n"
 
 printf "Getting Users meta data..."
 	wget https://slack.com/api/users.list?token=$slack_token -O "users.list.json" 1>$logs/wget_meta02.log 2>&1
-	cat users.list.json | sed 's/{\"ok\":true,\"members\"://1' | sed '$ s/.$//' > users.json
+	cat users.list.json | sed 's/{\"ok\":true,\"members\"://1' | sed '$ s/.$//' | sed 's/\,\"cache_ts\":[0-9]*$//' > users.json
 	mv users.list.json $debug
 	mv users.json $directory
 printf "done.\n"


### PR DESCRIPTION
The current `sed` commands remove the first part and the closing `}`, but there is also an additional attribute `cache_ts`, so the resulting file won't be valid JSON.  I added another `sed` command to fix that.  (Could possibly combine that with the other `sed` commands, but I've had enough `sed` and regex for one day. :stuck_out_tongue: )